### PR TITLE
Remove futures dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,4 +19,3 @@ quote = "1.0"
 
 [dev-dependencies]
 smol = "0.1"
-futures = "0.3"

--- a/README.md
+++ b/README.md
@@ -26,8 +26,6 @@ async fn main() {
 
 ### Multi threads
 
-[futures](https://crates.io/crates/futures) is required because of using [`pending()`](https://docs.rs/futures/0.3.4/futures/future/fn.pending.html)
-
 ```rust
 #[smol_potat::main(threads=3)]
 async fn main() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,7 +100,7 @@ pub fn main(attr: TokenStream, item: TokenStream) -> TokenStream {
                     #body
                 }
 
-                pub struct Pending;
+                struct Pending;
 
                 impl std::future::Future for Pending {
                     type Output = ();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@ use syn::spanned::Spanned;
 /// }
 /// ```
 ///
-/// For multi-threads, first make sure `futures` crate is imported. And then add this to the attribute:
+/// For multi-threads, add this to the attribute:
 ///
 /// ```ignore
 /// #[smol_potat::main(threads=3)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@ use syn::spanned::Spanned;
 /// }
 /// ```
 /// 
-/// For multi-threads, first make sure `futures` crate is imported. And then add this to the attribute:
+/// For multi-threads, add this to the attribute:
 ///
 /// ```ignore
 /// #[smol_potat::main(threads=3)]


### PR DESCRIPTION
`futures` is a pretty big dependency when all you really want is a function that returns `Pending`.

`Futures` is also far from the only crate that has that functionality, so it seems silly to tie users to it

This pull request removes that dependency.