### PR TITLE
Adapt for smol 1.0, also bring back removed functionality

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "smol-potat"
 description = "Proc macro for smol runtime."
 license = "MIT OR Apache-2.0"
-version = "0.5.0"
+version = "1.0.0"
 authors = ["YuWeiWu <wusyong9104@gmail.com>"]
 edition = "2018"
 readme = "README.md"
@@ -11,9 +11,17 @@ homepage = "https://github.com/wusyong/smol-potat"
 documentation = "https://docs.rs/smol-potat"
 
 [dependencies]
-num_cpus = "1.13"
-smol-potat-macro = { version = "0.3", path = "smol-potat-macro"}
-smol = "0.3"
+smol-potat-macro = { version = "0.4", path = "smol-potat-macro"}
+num_cpus = { version = "1.13", optional = true }
+smol = "1.0"
+async-channel = "1.4"
+async-executor = "1.1"
+futures-lite = "1.7"
+easy-parallel = "3.1"
+
+
+[features]
+auto = ["smol-potat-macro/auto", "num_cpus"]
 
 [workspace]
 members = [

--- a/README.md
+++ b/README.md
@@ -15,6 +15,32 @@ Usage is similar to what you do in `tokio` and `async-std`.
 
 ## Usage
 
+### Single thread
+
+```rust
+#[smol_potat::main]
+async fn main() {
+    println!("Hello, world!");
+}
+```
+
+### Multi threads
+
+```rust
+#[smol_potat::main(threads=3)]
+async fn main() {
+    println!("Hello, world!");
+}
+```
+
+### Auto thread generation
+
+Enable `auto` feature and the rest is same as single thread:
+
+```
+smol_potat = { version = "1", features = ["auto"] }
+```
+
 ```rust
 #[smol_potat::main]
 async fn main() {

--- a/examples/main-multi-threads.rs
+++ b/examples/main-multi-threads.rs
@@ -1,6 +1,6 @@
 use smol::Executor;
 
-#[smol_potat::main]
+#[smol_potat::main(threads = 3)]
 async fn main() {
     let ex = Executor::new();
 

--- a/smol-potat-macro/Cargo.toml
+++ b/smol-potat-macro/Cargo.toml
@@ -2,7 +2,7 @@
 name = "smol-potat-macro"
 description = "Proc macro for smol runtime."
 license = "MIT OR Apache-2.0"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["YuWeiWu <wusyong9104@gmail.com>"]
 edition = "2018"
 repository = "https://github.com/wusyong/smol-potat"
@@ -17,4 +17,4 @@ syn = { version = "1.0", features = ["full"] }
 quote = "1.0"
 
 [features]
-tokio02 = []
+auto = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,14 @@
+#[doc(hidden)]
+pub use async_channel;
+#[doc(hidden)]
+pub use async_executor;
+#[doc(hidden)]
+pub use easy_parallel;
+#[doc(hidden)]
+pub use futures_lite;
+#[cfg(feature = "auto")]
 pub use num_cpus;
-pub use smol::*;
+#[doc(hidden)]
+pub use smol::block_on;
+
 pub use smol_potat_macro::{bench, main, test};

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,4 +1,5 @@
 #[smol_potat::test]
-async fn test() {
+async fn test() -> std::io::Result<()> {
     assert_eq!(2 * 2, 4);
+    Ok(())
 }


### PR DESCRIPTION
The auto feature and configurable thread count is back, also the
version of smol-potat was bumped to 1.0.0, smol-potat-macro was
bumped to 0.4.