### PR TITLE
Be compatible with `smol::spawn`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,13 +12,11 @@ documentation = "https://docs.rs/smol-potat"
 
 [dependencies]
 smol-potat-macro = { version = "0.4", path = "smol-potat-macro"}
+async-io = "1.1.10"
 num_cpus = { version = "1.13", optional = true }
-smol = "1.0"
-async-channel = "1.4"
-async-executor = "1.1"
-futures-lite = "1.7"
-easy-parallel = "3.1"
 
+[dev-dependencies]
+smol = "1.2.4"
 
 [features]
 auto = ["smol-potat-macro/auto", "num_cpus"]

--- a/examples/main-multi-threads.rs
+++ b/examples/main-multi-threads.rs
@@ -1,10 +1,6 @@
-use smol::Executor;
-
 #[smol_potat::main(threads = 3)]
 async fn main() {
-    let ex = Executor::new();
-
-    ex.run(async {
+    smol::spawn(async {
         println!("Hello, world!");
     })
     .await;

--- a/examples/main.rs
+++ b/examples/main.rs
@@ -1,10 +1,6 @@
-use smol::Executor;
-
 #[smol_potat::main]
 async fn main() {
-    let ex = Executor::new();
-
-    ex.run(async {
+    smol::spawn(async {
         println!("Hello, world!");
     })
     .await;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,16 +1,10 @@
 //! Attribute macros for [`smol`](https://github.com/stjepang/smol).
 
 #[doc(hidden)]
-pub use async_channel;
-#[doc(hidden)]
-pub use async_executor;
-#[doc(hidden)]
-pub use easy_parallel;
-#[doc(hidden)]
-pub use futures_lite;
+pub use async_io;
 #[cfg(feature = "auto")]
 pub use num_cpus;
 #[doc(hidden)]
-pub use smol::block_on;
+pub use std;
 
 pub use smol_potat_macro::{bench, main, test};


### PR DESCRIPTION
Smol has its own thread pool, and currrently using `smol-potat` and `smol::spawn` will create two thread pools: one by `smol-potat` and one by `smol`. This PR fixes this by just having `smol-potat` use `smol`'s thread pool.